### PR TITLE
Locate WebHooks by hookID

### DIFF
--- a/src/pages/api/webhooks/webhook.ts
+++ b/src/pages/api/webhooks/webhook.ts
@@ -2,16 +2,6 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import * as crypto from "crypto";
 import { env } from '~/env.mjs';
 
-interface IssuePayload {
-  issue: {
-    html_url: string;
-    title: string;
-  };
-  repository: {
-    name: string;
-  };
-}
-
 export default function webhooksHandler(
   req: NextApiRequest,
   res: NextApiResponse
@@ -28,17 +18,9 @@ export default function webhooksHandler(
     res.status(401).send("Unauthorized");
     return;
   }
-
+  
   if (req.method === 'POST') {
-    const payload = req.body as IssuePayload;
-    const issueTitle = payload.issue.title;
-    const repositoryName = payload.repository.name;
-    const issueUrl = payload.issue.html_url;
-
-    console.log(`Webhook received for issue: ${issueTitle}`);
-    console.log(`Repository: ${repositoryName}`);
-    console.log(`Issue URL: ${issueUrl}`);
-
+    console.log('webhook received: ', req.headers["x-github-hook-id"]);
     res.status(200).send('Webhook received successfully');
   }
 }

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -1,13 +1,15 @@
 import { Octokit } from "@octokit/rest";
 import { z } from "zod";
+import { env } from "~/env.mjs";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const webhookRouter = createTRPCRouter({
   createWebhook: protectedProcedure.input(z.object({ accessToken: z.string()})).mutation(async ({ input }) => {
     const owner = "GabrielPedroza";
-    const repo = "e-commerce";
+    const repo = "exotica";
 
-    const WEBHOOK_URL = "https://bread-meta.vercel.app/api/webhooks/webhook";
+    const WEBHOOK_URL = "https://hkdk.events/G3KE7hkFpr5I";
+    // const WEBHOOK_URL = "https://bread-meta.vercel.app/api/webhooks/webhook";
     
     const octokit = new Octokit({
       auth: input.accessToken
@@ -20,14 +22,14 @@ export const webhookRouter = createTRPCRouter({
         name: 'web',
         active: true,
         events: [
-          'push',
           "issues",
           'pull_request'
         ],
         config: {
           url: WEBHOOK_URL,
           content_type: 'json',
-          insecure_ssl: '0'
+          insecure_ssl: '0',
+          secret: env.WEBHOOK_SECRET
         },
         headers: {
           'X-GitHub-Api-Version': '2022-11-28'
@@ -35,15 +37,20 @@ export const webhookRouter = createTRPCRouter({
       })
 
       if (response.status === 201) {
-        console.log("Webhook created successfully", response);
+        // response.headers.location example - location: 'https://api.github.com/repos/GabrielPedroza/exotica/hooks/425484562'
+        const locationURL = response.headers.location!
+        const lastURLSlash = locationURL.lastIndexOf("/")
+        const hookID = locationURL.slice(lastURLSlash + 1)
+        console.log("Webhook created successfully", hookID);
       } else {
         console.error("Error Status: ", response.status, response)
       }
 
     } catch (error) {
       console.error("Error creating webhook:", error);
+      return false
     }
 
-    return "Webhook created successfully";
+    return true
   }),
 });


### PR DESCRIPTION
## Description

PR Accomplishment: Putting an identity to the WebHook and being able to easily identify it later on when an alert has been received from the exposed api endpoint.

Future PR Accomplishment: Perform CRUD operations on appropriate Automations and WebHooks.

## Milestones

This milestone is working towards identifying the WebHook itself upon creation. When an alert is sent from GitHub or any other provider, a hook ID is tied to the WebHook so it can easily be found and perform logic on it. This also includes the WebHook secret that will make WebHooks safe. In order to view the contents of the WebHook, you need the same random string with high entropy and convert it into a SHA-256 hash signature.

## Test Plan
Creating a tunnel (ngrok and tl) was not an option as it requires permissions from the work laptop. To bypass this, creating a WebHook proxy (hookdeck console) works perfectly as it satisfies both GitHub and the local developer experience.

1. Install the Hookdeck CLI on your device
    Whether that'd be `brew install hookdeck/hookdeck/hookdeck` for mac or 
    `scoop bucket add hookdeck https://github.com/hookdeck/scoop-hookdeck-cli.git` && `scoop install hookdeck` for 
    windows. For more ways to install, visit: https://console.hookdeck.com/
2. Visiting this link (https://console.hookdeck.com/) will show you the next 2 steps: 
    hookdeck login --cli-key YOUR_CLI_KEY
    hookdeck listen [port] Source (in our case, the port will be 3000)
3. Once you've followed the previous steps and hookdeck is running in your terminal, you will be presented with a question:
    What path should the webhooks be forwarded to (ie: /webhooks)?
    Enter the following: `/api/webhooks/webhook`
4. After following the previous step, you will receive one more question: 
    What's your connection label (ie: My API)?
    Enter the following: github
5. Now, you will receive a WebHook URL in the terminal. An example of this will look like the following:
    Source
🔌 Webhook URL: https://hkdk.events/G3KE7hkFpr5I
6. Replace the existing WebHook URL link in the code from the following file: `src/server/api/routers/webhook.ts`
    ‼️ Remember to have your WebHook secret created. Follow the previous PR's test plan if you haven't done already: 
    https://github.com/GabrielPedroza/bread/pull/8
