### PR TITLE
Update Access Token in DB if stale | Format

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -25,7 +25,7 @@ model Example {
 // Necessary for Next auth
 model Account {
     id                String  @id @default(cuid())
-    userId            String
+    userId            String  @unique
     type              String
     provider          String
     providerAccountId String

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -4,53 +4,81 @@ import { env } from "~/env.mjs";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
 export const webhookRouter = createTRPCRouter({
-  createWebhook: protectedProcedure.input(z.object({ accessToken: z.string()})).mutation(async ({ input }) => {
+  // accessToken is optional because there can be instances where the user's session is remembered which makes the accessToken undefined.
+  // if this occurs, we use the accessToken in the DB and if that is stale, we require the user to log out and log back in.
+  createWebhook: protectedProcedure.input(z.object({ accessToken: z.string().optional() })).mutation(async ({ ctx, input }) => {
     const owner = "GabrielPedroza";
     const repo = "exotica";
 
     const WEBHOOK_URL = "https://hkdk.events/G3KE7hkFpr5I";
     // const WEBHOOK_URL = "https://bread-meta.vercel.app/api/webhooks/webhook";
+
+    // grabbing DB access token
+    const accessToken = await ctx.prisma.account.findFirst({
+    where: {
+      userId: ctx.session.user.id,
+    },
+    select: {
+      access_token: true,
+    },
+  })
+  .then((account) => account?.access_token);
+  
+  // if access token on DB is stale, update it. Not doing so will cause a 401 Error: Bad Credentials
+  if (input.accessToken != undefined && input.accessToken !== accessToken) {
+    console.log("update token");
     
+    await ctx.prisma.account.update({
+      where: {
+        userId: ctx.session.user.id,
+      },
+      data: {
+        access_token: input.accessToken,
+      },
+    });
+  }
+
     const octokit = new Octokit({
-      auth: input.accessToken
-    })
+      auth: input.accessToken || accessToken
+    });
+
+    let hookID = "";
 
     try {
-      const response = await octokit.request('POST /repos/{owner}/{repo}/hooks', {
+      const response = await octokit.request("POST /repos/{owner}/{repo}/hooks", {
         owner,
         repo,
-        name: 'web',
+        name: "web",
         active: true,
         events: [
           "issues",
-          'pull_request'
+          "pull_request"
         ],
         config: {
           url: WEBHOOK_URL,
-          content_type: 'json',
-          insecure_ssl: '0',
+          content_type: "json",
+          insecure_ssl: "0",
           secret: env.WEBHOOK_SECRET
         },
         headers: {
-          'X-GitHub-Api-Version': '2022-11-28'
+          "X-GitHub-Api-Version": "2022-11-28"
         }
-      })
+      });
 
       if (response.status === 201) {
-        // response.headers.location example - location: 'https://api.github.com/repos/GabrielPedroza/exotica/hooks/425484562'
-        const locationURL = response.headers.location!
-        const lastURLSlash = locationURL.lastIndexOf("/")
-        const hookID = locationURL.slice(lastURLSlash + 1)
+        // response.headers.location example - location: "https://api.github.com/repos/GabrielPedroza/exotica/hooks/425484562"
+        const locationURL = response.headers.location!;
+        const lastURLSlash = locationURL.lastIndexOf("/");
+        hookID = locationURL.slice(lastURLSlash + 1);
         console.log("Webhook created successfully", hookID);
       } else {
-        console.error("Error Status: ", response.status, response)
-      }
+        return false;
+      };
 
     } catch (error) {
-      console.error("Error creating webhook:", error);
-      return false
+      return false;
     }
-
-    return true
+    // returning hookID so automation model can grab it. occurs in src/components/FormType.tsx
+    return hookID;
   }),
 });

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -67,13 +67,14 @@ export const webhookRouter = createTRPCRouter({
 
       if (response.status === 201) {
         // response.headers.location example - location: "https://api.github.com/repos/GabrielPedroza/exotica/hooks/425484562"
+        {/* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */}
         const locationURL = response.headers.location!;
         const lastURLSlash = locationURL.lastIndexOf("/");
         hookID = locationURL.slice(lastURLSlash + 1);
         console.log("Webhook created successfully", hookID);
       } else {
         return false;
-      };
+      }
 
     } catch (error) {
       return false;

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -3,8 +3,13 @@ import { z } from "zod";
 import { env } from "~/env.mjs";
 import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 
+interface GitHubAPIError {
+  status: number;
+}
+
 export const webhookRouter = createTRPCRouter({
-  // accessToken is optional because there can be instances where the user's session is remembered which makes the accessToken undefined.
+  // accessToken is optional because there can be instances where the user's session is remembered (automatically is redirected to hompage) 
+  // which makes the accessToken undefined since accessToken is grabbed when user is loggin in (authenticating).
   // if this occurs, we use the accessToken in the DB and if that is stale, we require the user to log out and log back in.
   createWebhook: protectedProcedure.input(z.object({ accessToken: z.string().optional() })).mutation(async ({ ctx, input }) => {
     const owner = "GabrielPedroza";
@@ -26,8 +31,6 @@ export const webhookRouter = createTRPCRouter({
   
   // if access token on DB is stale, update it. Not doing so will cause a 401 Error: Bad Credentials
   if (input.accessToken != undefined && input.accessToken !== accessToken) {
-    console.log("update token");
-    
     await ctx.prisma.account.update({
       where: {
         userId: ctx.session.user.id,
@@ -37,7 +40,7 @@ export const webhookRouter = createTRPCRouter({
       },
     });
   }
-
+    // getting authorization using accessToken to create webhook
     const octokit = new Octokit({
       auth: input.accessToken || accessToken
     });
@@ -72,14 +75,25 @@ export const webhookRouter = createTRPCRouter({
         const lastURLSlash = locationURL.lastIndexOf("/");
         hookID = locationURL.slice(lastURLSlash + 1);
         console.log("Webhook created successfully", hookID);
-      } else {
-        return false;
       }
 
     } catch (error) {
+      if (isGitHubAPIError(error)) {
+        // if 422: hook already exists in the repository
+        if (error.status === 422) {
+          return 422
+        }
+      }
+      // a possible error can be 401: Bad Credentials if DB accessToken is stale AND user's session is remembered. 
+      // We require the user to log out and log in.
       return false;
     }
     // returning hookID so automation model can grab it. occurs in src/components/FormType.tsx
     return hookID;
   }),
 });
+  {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+const isGitHubAPIError = (error: any): error is GitHubAPIError => {
+  {/* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access */}
+  return typeof error.status === "number"
+}


### PR DESCRIPTION
## Description

PR Accomplishment: Apart from formatting changes that were made in this PR, Access Tokens are short-lived tokens that became stale after x amount of time which causes a 401 error: Bad Credentials to occur. This was fixed by updating the access token in the current user session's accessToken upon logging in. Also, when using the `try, catch` block, the error was of type `any` or `unknown` implicitly so there is a function that gives error a type with types that are expected from GitHub's response. 

Future PR Accomplishment: Have a more thorough formatting when developing continuously using prettier. Continue with the goal of an e2e implementation of the project.

## Milestones

This was a milestone because if the token was stale, the user would not be able to create a WebHook which caused a domino effect of not having an automation created.

## Test Plan

To test the validity of the access token, the tester will first authenticate with GitHub to be redirected in the homepage.

‼️ Remember: if the user is in the homepage, they have an existing session. 

Upon creating a GitHub WebHook, using the create button, you should see in the server that a WebHook has been created (https://ibb.co/j8wrKDS). In the browser's console, you can see the query and mutation hooks in action including the createAutomation mutation and query running (https://ibb.co/pfv2bBR) (refer to PR https://github.com/GabrielPedroza/bread/pull/12 for more info on automations). Once the WebHook has been created, refreshing the page will show you the newly created automation. From creating the WebHook to creating the automation, the access token was needed to be valid. 

The access token is being used in `src/server/api/routers/webhook.ts`. If you go to another tab, refresh the page, or just wait until tomorrow, the access token can become undefined in the user's session. The reason for this is because the access token is grabbed during the authentication stage. If, for example, you refresh the page, the session might revalidate/refresh and that can cause the access token to be undefined. That is when we use the token from the database and if that is stale, then we require the user to log out and log back in (error handling with logging). Logging out and logging back in will then get the access token from the session and when a WebHook is created, it will update the access token in the database.

To test the error block from the `try, catch`, you can create two of the same webHooks in the same repository and see that it will return a error code 422 which is "Hook already exists in this repository". A user can have up to 10 WebHooks in a single repository but if any overlap, then you will get a 422. For example, you can have a WebHook that listens for PR's and another that listens for Issues and Stars in the same repo but you cannot have a WebHook that listens for PR's and another that listens for PR's and Issues.