### PR TITLE
Remove Hardcode Forms | Hover Over Automation Name & Description

### DIFF
--- a/src/components/UserAutomations.tsx
+++ b/src/components/UserAutomations.tsx
@@ -90,7 +90,13 @@ const UserAutomations = () => {
                 <div className="relative top-[0.15rem] -ml-10 w-40 truncate text-amber-950">
                   {automation.name}
                 </div>
-                <div className="hover: relative top-[0.15rem] -ml-10 w-44 truncate text-amber-950">
+                <div className="absolute left-8 z-50 max-h-fit max-w-[30ch] cursor-default overflow-hidden scroll-auto whitespace-normal border-2 bg-slate-50 text-center opacity-0 transition-all hover:opacity-100">
+                  {automation.name}
+                </div>
+                <div className="relative top-[0.15rem] -ml-10 w-44 truncate text-amber-950">
+                  {automation.desc}
+                </div>
+                <div className="absolute z-50 max-h-fit max-w-[30ch] cursor-default overflow-hidden scroll-auto whitespace-normal border-2 bg-slate-50 text-center opacity-0 transition-all hover:opacity-100">
                   {automation.desc}
                 </div>
                 <div>

--- a/src/server/api/routers/automation.ts
+++ b/src/server/api/routers/automation.ts
@@ -5,8 +5,8 @@ const createAutomationSchema = z.object({
   name: z.string(),
   desc: z.string(),
   webhookID: z.string(),
-  condition: z.enum(["issues", "pull_request"]),
-  actionType: z.enum(["email"]),
+  condition: z.enum(["issues", "pull_request", "push", "star", ""]),
+  actionType: z.enum(["email", ""]),
 });
 
 export const automationRouter = createTRPCRouter({

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -18,10 +18,17 @@ export const webhookRouter = createTRPCRouter({
   // which makes the accessToken undefined since accessToken is grabbed when user is logging in (authenticating).
   // if this occurs, we use the accessToken in the DB and if that is stale, we require the user to log out and log back in.
   createWebhook: protectedProcedure
-    .input(z.object({ accessToken: z.string().optional() }))
+    .input(
+      z.object({
+        accessToken: z.string().optional(),
+        repository: z.string(),
+        events: z.enum(["issues", "pull_request", "push", "star", ""]),
+        owner: z.string(),
+      })
+    )
     .mutation(async ({ ctx, input }): Promise<WebHookReturnObject> => {
-      const owner = "GabrielPedroza";
-      const repo = "exotica";
+      const owner = input.owner;
+      const repo = input.repository;
 
       const WEBHOOK_URL = "https://hkdk.events/G3KE7hkFpr5I";
       // const WEBHOOK_URL = "https://bread-meta.vercel.app/api/webhooks/webhook";
@@ -64,7 +71,7 @@ export const webhookRouter = createTRPCRouter({
             repo,
             name: "web",
             active: true,
-            events: ["issues", "pull_request"],
+            events: [input.events],
             config: {
               url: WEBHOOK_URL,
               content_type: "json",


### PR DESCRIPTION
## Description

PR Accomplishment: Remove Hardcode in ruleset form so now user can input their repository and event type (missing delete webhook). Added extra input fields to ruleset form. Hovering over the name and description automations can show the full text of what was written if the text was initially truncated. 

Future PR Accomplishment: User can use recommended automation | Create a step-by-step process to use this project

## Milestones

Users can now input their own repos and event to use it themselves!

## Test Plan

Changes to Ruleset form component was made. Depending on the option you've chose, you will see different input boxes. See UI Test Plan.

After creating your SendGrid API KEY (refer to PR https://github.com/GabrielPedroza/bread/pull/14) and changing your target email to an email that you can see the inbox to, follow the steps to create an automation and after the event trigger has been activated, you should receive an email to your inbox.

UI Test Plan:

As of right now, there is only one way that you can create an automation (event type **repo** and action type **email**). When you select these options, input boxes should appear with information you can enter. See UI images below on these steps

Ruleset automation: https://ibb.co/Js5SKdH | https://ibb.co/NNpX80q
Ruleset automation with repo event: https://ibb.co/7GtCGFx
Ruleset automation with custom automation name and desc: https://ibb.co/whVtfFV
User recently created Automation: https://ibb.co/TBmcKw2
User hovers on description: https://ibb.co/YtKpbhq | https://ibb.co/0Bnyqnr
