### PR TITLE
removed hardcode from webhook delete

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,8 @@ model Automation {
   webhookID  String
   condition  String
   name       String
+  owner      String
+  repository String
   desc       String
   status     String
 

--- a/src/components/FormType.tsx
+++ b/src/components/FormType.tsx
@@ -109,6 +109,8 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
           await createAutomation.mutateAsync({
             name: automationName,
             desc: automationDescription,
+            owner,
+            repository: repositoryName,
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             webhookID: createWebhookResultObject.data!, // this will have data guaranteed
             actionType: thenCondition,

--- a/src/server/api/routers/automation.ts
+++ b/src/server/api/routers/automation.ts
@@ -4,6 +4,8 @@ import { createTRPCRouter, protectedProcedure } from "~/server/api/trpc";
 const createAutomationSchema = z.object({
   name: z.string(),
   desc: z.string(),
+  owner: z.string(),
+  repository: z.string(),
   webhookID: z.string(),
   condition: z.enum(["issues", "pull_request", "push", "star", ""]),
   actionType: z.enum(["email", ""]),
@@ -30,6 +32,8 @@ export const automationRouter = createTRPCRouter({
           webhookID: input.webhookID,
           name: input.name,
           desc: input.desc,
+          owner: input.owner,
+          repository: input.repository,
           status: "active",
           condition: input.condition,
           action: { connect: { id: action.id } },

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -129,8 +129,15 @@ export const webhookRouter = createTRPCRouter({
   deleteWebhook: protectedProcedure
     .input(z.object({ accessToken: z.string().optional(), hookID: z.number() }))
     .mutation(async ({ ctx, input }): Promise<WebHookReturnObject> => {
-      const owner = "GabrielPedroza";
-      const repo = "exotica";
+      const automation = await ctx.prisma.automation.findFirst({
+        where: {
+          webhookID: String(input.hookID),
+        },
+        select: {
+          owner: true,
+          repository: true,
+        },
+      });
 
       // grabbing DB access token
       const accessToken = await ctx.prisma.account
@@ -165,8 +172,10 @@ export const webhookRouter = createTRPCRouter({
         const response = await octokit.request(
           "DELETE /repos/{owner}/{repo}/hooks/{hook_id}",
           {
-            owner,
-            repo,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+            owner: automation?.owner!,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
+            repo: automation?.repository!,
             hook_id: input.hookID,
             headers: {
               "X-GitHub-Api-Version": "2022-11-28",


### PR DESCRIPTION
## Description

PR Accomplishment: User can now create and remove their automation because of the webhook delete backend function

Future PR Accomplishment: Refer to https://github.com/GabrielPedroza/bread/pull/22

## Milestones

A working solution for creating and deleting automations completely

## Test Plan

(DEPRECATED): New implementation of webhook delete in PR https://github.com/GabrielPedroza/bread/pull/24

Refer to PR https://github.com/GabrielPedroza/bread/pull/12 to create an automation

After its creation, proceed to delete said automation and you should see the toast notification (webhook removed) as well as the webhook being removed in your specified repository
