### PR TITLE
Remove hardcode emails | Defer action | remove session accessToken

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -102,7 +102,7 @@ model Action {
   // if actionType is email
   toEmail       String?
   subject       String?
-  content       String?
+  scheduleSend  Int?
 
   // more actionType here and below
 

--- a/src/components/FormType.tsx
+++ b/src/components/FormType.tsx
@@ -58,6 +58,11 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
   >("");
   const [thenCondition, setThenCondition] = useState<"email" | "">("");
 
+  const [emailSelected, setEmailSelected] = useState(false)
+  const [toEmail, setToEmail] = useState("")
+  const [emailSubject, setEmailSubject] = useState("")
+  const [scheduleSend, setScheduleSend] = useState(0)
+
   const [automationName, setAutomationName] = useState("");
   const [automationDescription, setAutomationDescription] = useState("");
 
@@ -79,7 +84,7 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
 
       // passing accessToken is necessary because DB access token can be stale which can cause 401: Bad Credentials
       const createWebhookResultObject = await createWebhook.mutateAsync({
-        accessToken: session.user.accessToken,
+        // accessToken: session.user.accessToken,
         repository: repositoryName,
         events: ifCondition,
         owner,
@@ -115,6 +120,9 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
             webhookID: createWebhookResultObject.data!, // this will have data guaranteed
             actionType: thenCondition,
             condition: ifCondition,
+            toEmail,
+            scheduleSend,
+            subject: emailSubject,
           });
         } catch (e) {
           toast.dismiss();
@@ -171,6 +179,7 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
     const eventValue = e.target.value;
     if (eventValue === "email") {
       setThenCondition(eventValue);
+      setEmailSelected(true)
     } else {
       setThenCondition("");
     }
@@ -263,6 +272,37 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
           {/* more options */}
         </select>
       </div>
+      {emailSelected ? (
+        <>
+          <div>
+            <input
+              type="text"
+              required
+              placeholder="Send Email To..."
+              onChange={(e) => setToEmail(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
+          <div>
+            <input
+              type="text"
+              required
+              placeholder="Subject of Email..."
+              onChange={(e) => setEmailSubject(e.target.value)}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
+          <div>
+            <input
+              type="number"
+              min={0}
+              placeholder="Schedule Send in Minute(s)..."
+              onChange={(e) => setScheduleSend(Number(e.target.value))}
+              className="w-full rounded border border-gray-300 px-3 py-2"
+            />
+          </div>
+        </>
+      ) : null}
       <div>
         <label htmlFor="" className="block font-medium text-white">
           Automation:

--- a/src/components/FormType.tsx
+++ b/src/components/FormType.tsx
@@ -58,10 +58,10 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
   >("");
   const [thenCondition, setThenCondition] = useState<"email" | "">("");
 
-  const [emailSelected, setEmailSelected] = useState(false)
-  const [toEmail, setToEmail] = useState("")
-  const [emailSubject, setEmailSubject] = useState("")
-  const [scheduleSend, setScheduleSend] = useState(0)
+  const [emailSelected, setEmailSelected] = useState(false);
+  const [toEmail, setToEmail] = useState("");
+  const [emailSubject, setEmailSubject] = useState("");
+  const [scheduleSend, setScheduleSend] = useState(0);
 
   const [automationName, setAutomationName] = useState("");
   const [automationDescription, setAutomationDescription] = useState("");
@@ -179,7 +179,7 @@ const GitHubFormType = ({ modals }: GitHubFormTypeProps) => {
     const eventValue = e.target.value;
     if (eventValue === "email") {
       setThenCondition(eventValue);
-      setEmailSelected(true)
+      setEmailSelected(true);
     } else {
       setThenCondition("");
     }

--- a/src/components/UserAutomations.tsx
+++ b/src/components/UserAutomations.tsx
@@ -30,6 +30,8 @@ const UserAutomations = () => {
       const deleteWebHookResultObject = await deleteWebHook.mutateAsync({
         hookID: Number(automation.webhookID),
         accessToken: session?.user.accessToken,
+        owner: automation.owner,
+        repository: automation.repository,
       });
 
       if (deleteWebHookResultObject.error) {

--- a/src/pages/api/webhooks/webhook.ts
+++ b/src/pages/api/webhooks/webhook.ts
@@ -1,8 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import * as crypto from "crypto";
 import { env } from "~/env.mjs";
-import { type AutomationAndActionByWebHookIDType, sendEmail } from "~/utils/sendEmail";
-import { PrismaClient } from '@prisma/client';
+import {
+  type AutomationAndActionByWebHookIDType,
+  sendEmail,
+} from "~/utils/sendEmail";
+import { PrismaClient } from "@prisma/client";
 
 const prisma = new PrismaClient();
 
@@ -28,9 +31,9 @@ export default async function webhooksHandler(
   const deliveryId = req.headers["x-github-delivery"];
 
   // eventType is guaranteed to be a string because with how ruleset form is set up, it only listens to one event. it will never be undefined
-  const eventType = req.headers["x-github-event"] as string
+  const eventType = req.headers["x-github-event"] as string;
   // GitHubWebHookID is guaranteed to be a string because the hook is tied to one event (even when multiple hooks are in one repo). it will never be undefined
-  const GitHubWebHookID = req.headers["x-github-hook-id"] as string
+  const GitHubWebHookID = req.headers["x-github-hook-id"] as string;
 
   // checks for duplicate webhooks
   if (receivedDeliveryIds.has(deliveryId)) {
@@ -45,10 +48,16 @@ export default async function webhooksHandler(
   }
 
   if (req.method === "POST") {
-    const automationAndActionByWebHookID = await fetchUserAutomationByHookID(GitHubWebHookID)
+    const automationAndActionByWebHookID = await fetchUserAutomationByHookID(
+      GitHubWebHookID
+    );
     if (automationAndActionByWebHookID?.action.actionType === "email") {
       // Action model in DB is denormalized which makes toEmail, subject, etc... optional. If actionType is email, the toEmail, subject, etc... are not null/undefined
-      sendEmail(automationAndActionByWebHookID as AutomationAndActionByWebHookIDType, req.body, eventType);
+      sendEmail(
+        automationAndActionByWebHookID as AutomationAndActionByWebHookIDType,
+        req.body,
+        eventType
+      );
     }
     res.status(200).send("Webhook received successfully");
 
@@ -64,7 +73,7 @@ async function fetchUserAutomationByHookID(WebhookID: string) {
   try {
     const userAutomation = await prisma.automation.findFirst({
       where: {
-        webhookID: WebhookID
+        webhookID: WebhookID,
       },
       select: {
         action: {
@@ -72,12 +81,12 @@ async function fetchUserAutomationByHookID(WebhookID: string) {
             toEmail: true,
             subject: true,
             actionType: true,
-            scheduleSend: true
-          }
-        }
-      }
+            scheduleSend: true,
+          },
+        },
+      },
     });
-    return userAutomation
+    return userAutomation;
   } finally {
     await prisma.$disconnect();
   }

--- a/src/pages/api/webhooks/webhook.ts
+++ b/src/pages/api/webhooks/webhook.ts
@@ -1,11 +1,14 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import * as crypto from "crypto";
 import { env } from "~/env.mjs";
-import { sendEmail } from "~/utils/sendEmail";
+import { type AutomationAndActionByWebHookIDType, sendEmail } from "~/utils/sendEmail";
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
 
 const receivedDeliveryIds = new Set();
 
-export default function webhooksHandler(
+export default async function webhooksHandler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
@@ -23,7 +26,11 @@ export default function webhooksHandler(
   }
 
   const deliveryId = req.headers["x-github-delivery"];
-  const eventType = req.headers["x-github-event"];
+
+  // eventType is guaranteed to be a string because with how ruleset form is set up, it only listens to one event. it will never be undefined
+  const eventType = req.headers["x-github-event"] as string
+  // GitHubWebHookID is guaranteed to be a string because the hook is tied to one event (even when multiple hooks are in one repo). it will never be undefined
+  const GitHubWebHookID = req.headers["x-github-hook-id"] as string
 
   // checks for duplicate webhooks
   if (receivedDeliveryIds.has(deliveryId)) {
@@ -38,7 +45,11 @@ export default function webhooksHandler(
   }
 
   if (req.method === "POST") {
-    sendEmail();
+    const automationAndActionByWebHookID = await fetchUserAutomationByHookID(GitHubWebHookID)
+    if (automationAndActionByWebHookID?.action.actionType === "email") {
+      // Action model in DB is denormalized which makes toEmail, subject, etc... optional. If actionType is email, the toEmail, subject, etc... are not null/undefined
+      sendEmail(automationAndActionByWebHookID as AutomationAndActionByWebHookIDType, req.body, eventType);
+    }
     res.status(200).send("Webhook received successfully");
 
     receivedDeliveryIds.add(deliveryId);
@@ -46,5 +57,28 @@ export default function webhooksHandler(
     setTimeout(() => {
       receivedDeliveryIds.delete(deliveryId);
     }, 3_600_000); // one hour
+  }
+}
+
+async function fetchUserAutomationByHookID(WebhookID: string) {
+  try {
+    const userAutomation = await prisma.automation.findFirst({
+      where: {
+        webhookID: WebhookID
+      },
+      select: {
+        action: {
+          select: {
+            toEmail: true,
+            subject: true,
+            actionType: true,
+            scheduleSend: true
+          }
+        }
+      }
+    });
+    return userAutomation
+  } finally {
+    await prisma.$disconnect();
   }
 }

--- a/src/server/api/routers/automation.ts
+++ b/src/server/api/routers/automation.ts
@@ -9,6 +9,11 @@ const createAutomationSchema = z.object({
   webhookID: z.string(),
   condition: z.enum(["issues", "pull_request", "push", "star", ""]),
   actionType: z.enum(["email", ""]),
+
+  // email event type
+  toEmail: z.string().optional(),
+  subject: z.string().optional(),
+  scheduleSend: z.number().optional()
 });
 
 export const automationRouter = createTRPCRouter({
@@ -17,15 +22,15 @@ export const automationRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const userID = ctx.session.user.id;
 
-      const action = await ctx.prisma.action.create({
-        data: {
-          hookID: input.webhookID,
-          actionType: input.actionType,
-          toEmail: "some email", // input.toEmail,
-          subject: "some subject", // input.subject,
-          content: "some content", // input.content,
-        },
-      });
+        const action = await ctx.prisma.action.create({
+          data: {
+            hookID: input.webhookID,
+            actionType: input.actionType,
+            toEmail: input.toEmail,
+            subject: input.subject,
+            scheduleSend: input.scheduleSend
+          },
+        });
 
       const automation = await ctx.prisma.automation.create({
         data: {

--- a/src/server/api/routers/automation.ts
+++ b/src/server/api/routers/automation.ts
@@ -13,7 +13,7 @@ const createAutomationSchema = z.object({
   // email event type
   toEmail: z.string().optional(),
   subject: z.string().optional(),
-  scheduleSend: z.number().optional()
+  scheduleSend: z.number().optional(),
 });
 
 export const automationRouter = createTRPCRouter({
@@ -22,15 +22,15 @@ export const automationRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const userID = ctx.session.user.id;
 
-        const action = await ctx.prisma.action.create({
-          data: {
-            hookID: input.webhookID,
-            actionType: input.actionType,
-            toEmail: input.toEmail,
-            subject: input.subject,
-            scheduleSend: input.scheduleSend
-          },
-        });
+      const action = await ctx.prisma.action.create({
+        data: {
+          hookID: input.webhookID,
+          actionType: input.actionType,
+          toEmail: input.toEmail,
+          subject: input.subject,
+          scheduleSend: input.scheduleSend,
+        },
+      });
 
       const automation = await ctx.prisma.automation.create({
         data: {

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -115,18 +115,15 @@ export const webhookRouter = createTRPCRouter({
     }),
 
   deleteWebhook: protectedProcedure
-    .input(z.object({ accessToken: z.string().optional(), hookID: z.number() }))
+    .input(
+      z.object({
+        accessToken: z.string().optional(),
+        owner: z.string(),
+        repository: z.string(),
+        hookID: z.number(),
+      })
+    )
     .mutation(async ({ ctx, input }): Promise<WebHookReturnObject> => {
-      const automation = await ctx.prisma.automation.findFirst({
-        where: {
-          webhookID: String(input.hookID),
-        },
-        select: {
-          owner: true,
-          repository: true,
-        },
-      });
-
       // grabbing DB access token
       const accessToken = await ctx.prisma.account
         .findFirst({
@@ -160,10 +157,8 @@ export const webhookRouter = createTRPCRouter({
         const response = await octokit.request(
           "DELETE /repos/{owner}/{repo}/hooks/{hook_id}",
           {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
-            owner: automation?.owner!,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, @typescript-eslint/no-non-null-asserted-optional-chain
-            repo: automation?.repository!,
+            owner: input.owner,
+            repo: input.repository,
             hook_id: input.hookID,
             headers: {
               "X-GitHub-Api-Version": "2022-11-28",

--- a/src/server/api/routers/webhook.ts
+++ b/src/server/api/routers/webhook.ts
@@ -20,7 +20,6 @@ export const webhookRouter = createTRPCRouter({
   createWebhook: protectedProcedure
     .input(
       z.object({
-        accessToken: z.string().optional(),
         repository: z.string(),
         events: z.enum(["issues", "pull_request", "push", "star", ""]),
         owner: z.string(),
@@ -45,20 +44,9 @@ export const webhookRouter = createTRPCRouter({
         })
         .then((account) => account?.access_token);
 
-      // if access token on DB is stale, update it. Not doing so will cause a 401 Error: Bad Credentials
-      if (input.accessToken != undefined && input.accessToken !== accessToken) {
-        await ctx.prisma.account.update({
-          where: {
-            userId: ctx.session.user.id,
-          },
-          data: {
-            access_token: input.accessToken,
-          },
-        });
-      }
       // getting authorization using accessToken to create webhook
       const octokit = new Octokit({
-        auth: input.accessToken || accessToken,
+        auth: accessToken,
       });
 
       let hookID = "";

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,12 +1,11 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { type GetServerSidePropsContext } from "next";
 import GitHubProvider from "next-auth/providers/github";
-import GoogleProvider from "next-auth/providers/google";
+// import GoogleProvider from "next-auth/providers/google";
 import {
   getServerSession,
   type NextAuthOptions,
   type DefaultSession,
-  type User,
 } from "next-auth";
 import { env } from "~/env.mjs";
 import { prisma } from "~/server/db";
@@ -34,13 +33,13 @@ declare module "next-auth" {
   }
 }
 
-interface UserWithAccessToken extends User {
-  tokens: {
-    access_token: string;
-  };
-}
+// interface UserWithAccessToken extends User {
+//   tokens: {
+//     access_token: string;
+//   };
+// }
 
-let profileWithAccessToken: UserWithAccessToken;
+// let profileWithAccessToken: UserWithAccessToken;
 
 /**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
@@ -55,7 +54,7 @@ export const authOptions: NextAuthOptions = {
         user: {
           ...session.user,
           id: user.id,
-          accessToken: profileWithAccessToken?.tokens.access_token,
+          // accessToken: profileWithAccessToken?.tokens.access_token,
         },
       };
     },
@@ -70,18 +69,19 @@ export const authOptions: NextAuthOptions = {
           scope: "repo",
         },
       },
-      profile: (profile, tokens) => {
-        if (tokens) {
-          /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
-          profileWithAccessToken = { ...profile, tokens };
-        }
-        return profileWithAccessToken;
-      },
+      // DANGEROUS SESSION ACCESS TOKEN - Errors when user first attempts to log in the site but works afterwards.
+      // profile: (profile, tokens) => {
+      //   if (tokens) {
+      //     /* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */
+      //     profileWithAccessToken = { ...profile, tokens };
+      //   }
+      //   return profileWithAccessToken;
+      // },
     }),
-    GoogleProvider({
-      clientId: env.GOOGLE_CLIENT,
-      clientSecret: env.GOOGLE_SECRET,
-    }),
+    // GoogleProvider({
+    //   clientId: env.GOOGLE_CLIENT,
+    //   clientSecret: env.GOOGLE_SECRET,
+    // }),
     /**
      * ...add more providers here.
      *

--- a/src/utils/sendEmail.ts
+++ b/src/utils/sendEmail.ts
@@ -4,17 +4,27 @@
 import sgMail from "@sendgrid/mail";
 import { env } from "~/env.mjs";
 
+export type AutomationAndActionByWebHookIDType = {
+  action: {
+      toEmail: string;
+      subject: string;
+      actionType: string;
+      scheduleSend: number;
+  };
+}
+
 // CHECK SPAM WHEN EXPECTING EMAILS
-export const sendEmail = () => {
+export const sendEmail = (automationAndActionByWebHookID: AutomationAndActionByWebHookIDType, bodyResponse: unknown, eventType: string) => {
+  const scheduleSendInSeconds = automationAndActionByWebHookID.action.scheduleSend
+  
   sgMail.setApiKey(env.SEND_GRID_API_KEY);
 
-  // info here will be grabbed from params that contain user's info from automation
   const msg = {
-    to: "gabrielpedroza2002167@gmail.com", // enter your email here for testing purposes
+    to: automationAndActionByWebHookID.action.toEmail, // enter your email here for testing purposes
     from: "BreadForMeta@gmail.com",
-    subject: "Sending with SendGrid is Fun",
-    text: "and easy to do anywhere, even with Node.js",
-    html: "<strong>and easy to do anywhere, even with Node.js</strong>",
+    subject: automationAndActionByWebHookID.action.subject,
+    text: JSON.stringify(bodyResponse),
+    sendAt: Math.floor((Date.now() / 1000) + (scheduleSendInSeconds * 60)) // defer email in UNIX Timestamp
   };
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   sgMail.send(msg);

--- a/src/utils/sendEmail.ts
+++ b/src/utils/sendEmail.ts
@@ -6,17 +6,22 @@ import { env } from "~/env.mjs";
 
 export type AutomationAndActionByWebHookIDType = {
   action: {
-      toEmail: string;
-      subject: string;
-      actionType: string;
-      scheduleSend: number;
+    toEmail: string;
+    subject: string;
+    actionType: string;
+    scheduleSend: number;
   };
-}
+};
 
 // CHECK SPAM WHEN EXPECTING EMAILS
-export const sendEmail = (automationAndActionByWebHookID: AutomationAndActionByWebHookIDType, bodyResponse: unknown, eventType: string) => {
-  const scheduleSendInSeconds = automationAndActionByWebHookID.action.scheduleSend
-  
+export const sendEmail = (
+  automationAndActionByWebHookID: AutomationAndActionByWebHookIDType,
+  bodyResponse: unknown,
+  eventType: string
+) => {
+  const scheduleSendInSeconds =
+    automationAndActionByWebHookID.action.scheduleSend;
+
   sgMail.setApiKey(env.SEND_GRID_API_KEY);
 
   const msg = {
@@ -24,7 +29,7 @@ export const sendEmail = (automationAndActionByWebHookID: AutomationAndActionByW
     from: "BreadForMeta@gmail.com",
     subject: automationAndActionByWebHookID.action.subject,
     text: JSON.stringify(bodyResponse),
-    sendAt: Math.floor((Date.now() / 1000) + (scheduleSendInSeconds * 60)) // defer email in UNIX Timestamp
+    sendAt: Math.floor(Date.now() / 1000 + scheduleSendInSeconds * 60), // defer email in UNIX Timestamp
   };
   // eslint-disable-next-line @typescript-eslint/no-floating-promises
   sgMail.send(msg);


### PR DESCRIPTION
## Description

PR Accomplishment: Emails are now not hardcoded and able to be executed with delay if user chooses it so. remove session access token because of initial error it causes (breaks production for brand new users)

Future PR Accomplishment: Refer to https://github.com/GabrielPedroza/bread/pull/24

## Milestones

THIRD TECHNICAL CHALLENGE DONE!!! (defer execution)

## Test Plan

Test Plan for remove hardcode emails: Refer to PR https://github.com/GabrielPedroza/bread/pull/23. New input fields so check images below.

Reason for removal of session access token: Refer to PR https://github.com/GabrielPedroza/bread/pull/11 for creation. This explanation has a bug. When the user first logs in with their GitHub account (as a brand new user), an error will occur: https://pastebin.com/jfNdUtNG
Test Plan for remove session access token: This question was asked in Web Tech Q&A. Access Token still works as intended but will expire after some time. Should not impede with demo

Test Plan for Defer action: Refer to PR https://github.com/GabrielPedroza/bread/pull/12 for how to create an automation. New Ruleset modal forms will be shown in the UI below. All fields are required except for delayed email (in minutes) input. If not entered, it will be zero and it is not possible to enter a number lower than 0. For testing purposes, input 1 or 2 minutes. This implementation also works if server restarts as it is stored as a scheduled email elsewhere from the project inside the API from SendGrid.

New Form input fields (including defer execution): https://ibb.co/SPK6ZgP

